### PR TITLE
fix: correct variable expansion

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,14 +23,18 @@ set(BUILD_SHARED_LIBS OFF)
 set(CMAKE_CXX_VISIBILITY_PRESET hidden)
 set(CMAKE_VISIBILITY_INLINES_HIDDEN ON)
 
-# Add main library
+# Add main library (TODO: use zip, not git clone)
 include(FetchContent)
 FetchContent_Declare(
   catima
   GIT_REPOSITORY https://github.com/hrosiak/catima.git
   )
-FetchContent_MakeAvailable(catima)
-
+FetchContent_GetProperties(catima)
+if(NOT catima_POPULATED)
+  FetchContent_Populate(catima)
+  set(APPS OFF)
+  add_subdirectory(${catima_SOURCE_DIR} ${catima_BINARY_DIR} EXCLUDE_FROM_ALL)
+endif()
 
 # Build extension
 find_package(pybind11 CONFIG REQUIRED)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,5 +22,3 @@ requires-python = ">=3.7"
 minimum-version = "0.2"
 build-dir = "build/{cache_tag}"
 wheel.packages = ["pycatima"]
-cmake.verbose = true
-logging.level = "DEBUG"


### PR DESCRIPTION
Once `catima` is releasing zips, we can move away from the `GIT` mechanism here, which is slower (and requires git)